### PR TITLE
if(!defined('DEF_FONTCOLOR')){//DEF_FONTCOLORの設定がないテンプレートの場合

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -560,9 +560,11 @@ unset($value);
 			//TAB
 			$tab=$oya+1;
 			//文字色
-			//$fontcolor = $fcolor ? $fcolor : DEF_FONTCOLOR;
-			$fontcolor = null; //compact()エラー回避暫定
-
+			if(!defined('DEF_FONTCOLOR')){//DEF_FONTCOLORの設定がないテンプレートの場合
+				define('DEF_FONTCOLOR','null');
+			}
+			$fontcolor = $fcolor ? $fcolor : DEF_FONTCOLOR;
+			// var_dump($fontcolor);
 			//<br />を<br>へ
 			$com = preg_replace("{<br( *)/>}i","<br>",$com);
 			//独自タグ変換


### PR DESCRIPTION
if(!defined('DEF_FONTCOLOR')){//DEF_FONTCOLORの設定がないテンプレートの場合
DEF_FONTCOLORを定義していない時はNULLになるので、未定義定数になりません。
文字色選択テンプレートがあれば対応可能にしておいてもいいのかもしれません。

> https://draclaw.com/other/distribute/

ここのテンプレートはCSSで文字の色を変更して表示しているので、もしかすると作者さんが改二用のCool Solidを作ってくれるかもしれません。
作ろうと思えば可能…な互換性を残しておいてもいいのではないでしょうか。