### PR TITLE
独自タグ関連エラー修正。

### DIFF
--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -658,7 +658,7 @@ unset($value);
 				//<br />を<br>へ
 				$com = preg_replace("{<br( *)/>}i","<br>",$com);
 				//独自タグ変換
-				if(USE_POTITAG) $com = potitag($com);
+				// if(USE_POTITAG) $com = potitag($com);
 
 				// レス記事一時格納
 				$rres[$oya][] = compact('no','sub','name','now','com','url','email','id','updatemark','trip','fontcolor'
@@ -3010,9 +3010,6 @@ paintform($picw,$pich,$palette,$anime);
 		break;
 	case 'catalog':
 		catalog();
-		break;
-	case 'tag':
-		potitagview();
 		break;
 	default:
 	if($res){


### PR DESCRIPTION
すでに修正ずみなのに古いファルをいじっていた可能性もあるのですが、なぜかエラーになったので独自タグ関連の箇所をコメントアウトしましました。