### PR TITLE
経過日数でミニレスフォームを閉じる $disp_resform = false;//ミニレスフォームを閉じる

### DIFF
--- a/potiboard2/config.php
+++ b/potiboard2/config.php
@@ -25,7 +25,7 @@ define('SHARE_BUTTON', '0');
 
 //ペイント画面のパスワードの暗号鍵
 //あまり頻繁に変えないように
-define('crypt_pass','fbgtK4pj9t8Auek');
+define('CRYPT_PASS','fbgtK4pj9t8Auek');
 
 //暗号化と解読のためのパスワード。
 //phpの内部で処理するので覚えておく必要はありません。
@@ -90,8 +90,7 @@ define('DENY_COMMENTS_URL', '0');
 //define('ELAPSED_DAYS','180');
 //	↑ 180日
 //で半年以上経過したスレッドに返信できなくなります。
-//設定すると各スレにフォームを表示するオプションは無効になり返信ボタン→レス画面になります。
-define('ELAPSED_DAYS','0');
+define('ELAPSED_DAYS','1');
 
 //拒絶するファイルのmd5
 $badfile = array("dummy","dummy2");
@@ -327,7 +326,6 @@ define('DEF_SUB', '無題');	//未入力時の題名
 define('USE_RESUB', '1');
 
 //各スレにレスフォームを表示する する:1 しない:0
-//ELAPSED_DAYSが0でない場合は強制的に0
 define('RES_FORM', '0');
 
 //フォーム下の追加お知らせ

--- a/potiboard2/potiboard.php
+++ b/potiboard2/potiboard.php
@@ -175,11 +175,11 @@ else{
 }
 
 //ペイント画面の$pwdの暗号化
-if(!defined('crypt_pass')){//config.phpで未定義なら初期値が入る
-define('crypt_pass','qRyFfhV6nyUggSb');//暗号鍵初期値
+if(!defined('CRYPT_PASS')){//config.phpで未定義なら初期値が入る
+define('CRYPT_PASS','qRyFfhV6nyUggSb');//暗号鍵初期値
 }
-define('crypt_method','aes-128-cbc');
-define('crypt_iv','T3pkYxNyjN7Wz3pu');//半角英数16文字
+define('CRYPT_METHOD','aes-128-cbc');
+define('CRYPT_IV','T3pkYxNyjN7Wz3pu');//半角英数16文字
 
 //指定した日数を過ぎたスレッドのフォームを閉じる
 if(!defined('ELAPSED_DAYS')){//config.phpで未定義なら0
@@ -422,13 +422,15 @@ unset($value);
 				 else{//フォームを閉じる日数が未設定なら
 				 $r_threads = true;
 				 }
-				 if(!$r_threads){
+				$disp_resform = true;
+				if(!$r_threads){
+					 $disp_resform = false;//ミニレスフォームを閉じる
 					 if($resno){//レスなら
 					 $dat['form'] = false;//フォームを閉じる
 					 $dat['paintform'] = false;
 					 }
 				 }
- 
+				
 			// URLとメールにリンク
 			//if($email) $name = "<a href=\"mailto:$email\">$name</a>";
 			if(AUTOLINK) $com = auto_link($com);
@@ -569,9 +571,9 @@ unset($value);
 			$descriptioncom=strip_tags($com);
 
 			// 親記事格納
-			$dat['oya'][$oya] = compact('src','srcname','size','painttime','pch','continue','thumb','imgsrc','w','h','no','sub','name','now','com','descriptioncom','limit','skipres','resub','url','email','id','updatemark','trip','tab','fontcolor');
+			$dat['oya'][$oya] = compact('src','srcname','size','painttime','pch','continue','thumb','imgsrc','w','h','no','sub','name','now','com','descriptioncom','limit','skipres','resub','url','email','id','updatemark','trip','tab','fontcolor','disp_resform');
 			// 変数クリア
-			unset($src,$srcname,$size,$painttime,$pch,$continue,$thumb,$imgsrc,$w,$h,$no,$sub,$name,$now,$com,$descriptioncom,$limit,$skipres,$resub,$url,$email);
+			unset($src,$srcname,$size,$painttime,$pch,$continue,$thumb,$imgsrc,$w,$h,$no,$sub,$name,$now,$com,$descriptioncom,$limit,$skipres,$resub,$url,$email,$disp_resform);
 
 			//レス作成
 			$rres=array();
@@ -761,11 +763,11 @@ unset($value);
 		}
 
 		if($resno){htmloutput(SKIN_DIR.RESFILE,$dat);break;}
-		// $dat['resform'] = RES_FORM ? true : false;
-		$dat['resform'] = false;	
-		if(RES_FORM && !ELAPSED_DAYS){
-			$dat['resform'] = true;	
-		}
+		$dat['resform'] = RES_FORM ? true : false;
+		// $dat['resform'] = false;	
+		// if(RES_FORM && !ELAPSED_DAYS){
+		// 	$dat['resform'] = true;	
+		// }
 		$buf = htmloutput(SKIN_DIR.MAINFILE,$dat,true);
 		if($page==0){$logfilename=PHP_SELF2;}
 			else{$logfilename=$page/PAGE_DEF.PHP_EXT;}
@@ -1897,7 +1899,7 @@ if($admin===$ADMIN_PASS){
 	$dat['stime'] = $stime;
 	//if($pwd) $pwd = substr(md5($pwd),2,8);
 	if($pwd){
-	$pwd=openssl_encrypt ($pwd,crypt_method, crypt_pass, true, crypt_iv);//暗号化
+	$pwd=openssl_encrypt ($pwd,CRYPT_METHOD, CRYPT_PASS, true, CRYPT_IV);//暗号化
 	$pwd=bin2hex($pwd);//16進数に
 	}
 	$resto = ($resto) ? '&amp;resto='.$resto : '';
@@ -2550,7 +2552,7 @@ function replace($no,$pwd,$stime){
 	// 記事上書き
 	$flag = false;
 	$pwd=hex2bin($pwd);//バイナリに
-	$pwd=openssl_decrypt($pwd,crypt_method, crypt_pass, true, crypt_iv);//復号化
+	$pwd=openssl_decrypt($pwd,CRYPT_METHOD, CRYPT_PASS, true, CRYPT_IV);//復号化
 
 	foreach($line as &$value){
 		list($eno,,$name,$email,$sub,$com,$url,$ehost,$epwd,$ext,$W,$H,$etim,,$eptime,$fcolor) = explode(",", rtrim($value));

--- a/potiboard2/skin/mono_main.html
+++ b/potiboard2/skin/mono_main.html
@@ -198,6 +198,7 @@
 							<% def(notres) %><span class="button"><a href="<% echo(self) %>?res=<% echo(oya/no) %>"><i class="fas fa-reply-all"></i> 返信</a></span> <a href="#header"><i class="fas fa-angle-double-up fa-fw fa-lg" title="一番上へ"></i></a><% /def %>
 							<% /def %>
 							<% def(resform) %>
+							<% def(oya/disp_resform) %>
 							<form class="resform" action="<% echo(self) %>" method="post" enctype="multipart/form-data">
 								<input type="hidden" name="mode" value="regist">
 								<input type="hidden" name="resto" value="<% echo(oya/no) %>">
@@ -211,6 +212,7 @@
 								<input class="button" type="submit" value="返信">
 								<a href="#header"><i class="fas fa-angle-double-up fa-fw fa-lg" title="一番上へ"></i></a>
 							</form>
+							<% /def %>
 							<% /def %>
 						</div>
 					</section>


### PR DESCRIPTION
要対応テンプレート。
&#x3C;% def(resform) %&#x3E;
&#x3C;% def(oya/disp_resform) %&#x3E;
(&#x3053;&#x3053;&#x306B;&#x30DF;&#x30CB;&#x30D5;&#x30A9;&#x30FC;&#x30E0;&#x306E;&#x30D1;&#x30FC;&#x30C4;)
&#x3C;% /def %&#x3E;
&#x3C;% /def %&#x3E;
デフォルトスキン修正ずみ。